### PR TITLE
add: support parse  object

### DIFF
--- a/demo/xiaoyuan/xiaoyuan.js
+++ b/demo/xiaoyuan/xiaoyuan.js
@@ -15,7 +15,13 @@ function prepareArgs(args) {
         if (arg instanceof NativePointer) {
             // 如果是 NativePointer，直接使用
             argPtr = arg;
-        } else if (typeof arg === 'number') {
+        }else if(typeof arg === 'object' ){
+            // 如果是对象，直接转换为指针
+            //形如 jstring Java_com_demo_app_genToken(JNIEnv *env, jobject obj, long str)这种registerNative的函数参数对象可以处理
+            argPtr = ptr(arg);
+        }
+    
+        else if (typeof arg === 'number') {
             // 如果是数字，直接转换为指针
             argPtr = ptr(arg);
         } else if (typeof arg === 'string') {


### PR DESCRIPTION
添加一个参数解析支持object类型，我在测试可以正常trace.
主要解决通过RegisterNatives函数注册的native方法，例如`jstring Java_com_demo_app_JNIHelper_genToken(JNIEnv* env,jobject,jlong)`这种形式的函数trace时参数解析问题。

在解析`object`类型参数时错误如下
```sh
Unsupported argument type at index 2: object
TypeError: Unsupported argument type at index 2: object
```
我试了下可以直接转为ptr就行了
